### PR TITLE
减小二进制文件体积, 更利于分发

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,15 @@ matrix:
 
 install:
   - rustup component add rustfmt clippy
+  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y upx; else brew install upx; fi
 script:
   - mkdir -p artifacts
   - cargo fmt --all -- --check
   - cargo clippy
   - cargo test --all
   - cargo build --release
+  - strip target/release/$BIN_NAME
+  - upx --ultra-brute target/release/$BIN_NAME
   - cp target/release/$BIN_NAME artifacts/$BIN_NAME-$TRAVIS_OS_NAME
 before_deploy:
   - export TRAVIS_TAG="preview"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
 members = ["seeker", "dnsserver", "ssclient", "sysconfig", "tun", "config", "crypto", "hermes/hermesdns"]
 
-#[profile.release]
+[profile.release]
+lto = true
+codegen-units = 1
+incremental = false
+opt-level = "z"
 #debug = true


### PR DESCRIPTION
稍微减小了生成二进制文件的大小

参照 https://jamesmunns.com/blog/tinyrocket/
还有一些方法没用上，有兴趣可以继续添加一下