### PR TITLE
优化探测策略

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,9 +691,9 @@ checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-io"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-lite"
@@ -1614,6 +1614,7 @@ dependencies = [
  "async-signals",
  "async-std",
  "async-std-resolver",
+ "async-tls",
  "base64",
  "bytes",
  "clap",

--- a/README.adoc
+++ b/README.adoc
@@ -94,7 +94,10 @@ tun_cidr: 10.0.0.0/16
 dns_listen: 0.0.0.0:53
 gateway_mode: true
 ping_timeout: 2s
-probe_timeout: 30ms  # probe_timeout 时间内如果 TCP 可以直接连接，则直连；否则走代理
+# probe_timeout 时间内如果可以建立 TCP 连接则直连（443端口会额外建立 SSL 连接），否则走代理。不要调的太低，国内有些网站会有很长的 SSL 握手时间。
+# 如果目标端口为 443，TCP 连接的超时时间为 probe_timeout， SSL 连接超时时间也为 probe_timeout，总的超时时间为 probe_timeout * 2;
+# 如果目标端口不为 443，TCP 连接的超时时间为 probe_timeout。
+probe_timeout: 200ms
 connect_timeout: 1s
 read_timeout: 30s
 write_timeout: 5s

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -157,7 +157,7 @@ fn parse_cidr(s: String) -> Ipv4Cidr {
 
 impl Config {
     pub fn from_config_file(path: &str) -> io::Result<Self> {
-        let file = File::open(&path).unwrap();
+        let file = File::open(path).unwrap();
         Config::from_reader(file)
     }
 

--- a/crypto/src/openssl.rs
+++ b/crypto/src/openssl.rs
@@ -113,7 +113,7 @@ impl OpenSSLCrypto {
         unsafe {
             buf.set_len(least_reserved);
         }
-        let length = self.inner.update(data, &mut *buf)?;
+        let length = self.inner.update(data, &mut buf)?;
         buf.truncate(length);
         out.put_slice(&buf);
         Ok(())
@@ -127,7 +127,7 @@ impl OpenSSLCrypto {
             buf.set_len(least_reserved);
         }
 
-        let length = self.inner.finalize(&mut *buf)?;
+        let length = self.inner.finalize(&mut buf)?;
         buf.truncate(length);
         out.put_slice(&buf);
         Ok(())

--- a/crypto/src/table.rs
+++ b/crypto/src/table.rs
@@ -33,7 +33,7 @@ impl TableCipher {
         }
 
         for i in 1..1024 {
-            table.sort_by(|x, y| (a % (*x + i)).cmp(&(a % (*y + i))))
+            table.sort_by_key(|x| a % (*x + i))
         }
 
         TableCipher {

--- a/sample_config.yml
+++ b/sample_config.yml
@@ -11,7 +11,7 @@ tun_ip: 11.0.0.1
 tun_cidr: 11.0.0.0/16
 dns_listen: 0.0.0.0:53
 gateway_mode: true
-probe_timeout: 100ms
+probe_timeout: 200ms
 ping_timeout: 2s
 connect_timeout: 2s
 read_timeout: 300s

--- a/seeker/Cargo.toml
+++ b/seeker/Cargo.toml
@@ -21,6 +21,7 @@ sysconfig = { path = "../sysconfig" }
 tun_nat = { path = "../tun_nat" }
 file-rotate = "0.7.0"
 async-std = "1.12.0"
+async-tls = "0.11"
 parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
 async-signals = "0.4.0"
 libc = "0.2.133"

--- a/seeker/src/main.rs
+++ b/seeker/src/main.rs
@@ -153,7 +153,13 @@ fn load_config(
     let remote_config = config.remote_config_urls.clone();
     let servers = Arc::make_mut(&mut config.servers);
     for url in remote_config {
-        let extra_servers = read_servers_from_remote_config(&url)?;
+        let extra_servers = match read_servers_from_remote_config(&url) {
+            Ok(servers) => servers,
+            Err(e) => {
+                println!("Load servers from remote config `{}` error: {}", url, e);
+                continue;
+            }
+        };
         servers.extend(extra_servers);
     }
     Ok(config)

--- a/seeker/src/main.rs
+++ b/seeker/src/main.rs
@@ -163,9 +163,9 @@ fn encrypt_config(path: Option<&str>, encrypt_key: Option<&str>) -> anyhow::Resu
     let (Some(path), Some(key)) = (path, encrypt_key) else {
         return Err(anyhow::anyhow!("path and encrypt_key must be provided"));
     };
-    let file = File::open(&path).context("Open config error")?;
-    return config_encryptor::encrypt_config(file, CipherType::ChaCha20Ietf, key)
-        .context("Encrypt config error");
+    let file = File::open(path).context("Open config error")?;
+    config_encryptor::encrypt_config(file, CipherType::ChaCha20Ietf, key)
+        .context("Encrypt config error")
 }
 
 fn read_servers_from_remote_config(url: &str) -> anyhow::Result<Vec<ServerConfig>> {

--- a/socks5_client/src/types.rs
+++ b/socks5_client/src/types.rs
@@ -325,6 +325,13 @@ impl Address {
             Address::DomainNameAddress(host, _) => Some(host),
         }
     }
+
+    pub fn port(&self) -> u16 {
+        match self {
+            Address::SocketAddress(s) => s.port(),
+            Address::DomainNameAddress(_, port) => *port,
+        }
+    }
 }
 
 impl Debug for Address {

--- a/ssclient/src/tcp_io/aead.rs
+++ b/ssclient/src/tcp_io/aead.rs
@@ -333,11 +333,11 @@ impl<T: Read + Write + Unpin> Write for EncryptedWriter<T> {
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        Pin::new(&mut (*self).conn).poll_flush(cx)
+        Pin::new(&mut self.conn).poll_flush(cx)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        Pin::new(&mut (*self).conn).poll_close(cx)
+        Pin::new(&mut self.conn).poll_close(cx)
     }
 }
 

--- a/ssclient/src/tcp_io/stream.rs
+++ b/ssclient/src/tcp_io/stream.rs
@@ -193,11 +193,11 @@ impl<T: Read + Write + Unpin> Write for EncryptedWriter<T> {
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        Pin::new(&mut (*self).conn).poll_flush(cx)
+        Pin::new(&mut self.conn).poll_flush(cx)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        Pin::new(&mut (*self).conn).poll_close(cx)
+        Pin::new(&mut self.conn).poll_close(cx)
     }
 }
 


### PR DESCRIPTION
1. 针对 443 端口，尝试建立 ssl 连接；其他端口只尝试建立 tcp 连接。

    有些域名可以建立 tcp 连接，但是无法建立 ssl 连接。

2. 在内存中缓存探测的结果。并且每次建立新连接的时候直接使用缓存，同时在后台单独起一个任务重新探测。